### PR TITLE
Fixed 'entity_encoding' parameter that loaded wrong 'tiny.element_format' value from Settings, added Entities parameter

### DIFF
--- a/_build/data/properties.inc.php
+++ b/_build/data/properties.inc.php
@@ -105,6 +105,13 @@ $properties = array(
         'value' => '',
     ),
     array(
+        'name' => 'entities',
+        'desc' => 'This option contains a comma separated list of entity names that is used instead of characters.',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+    ),
+    array(
         'name' => 'force_p_newlines',
         'desc' => 'This option enables you to disable/enable the creation of paragraphs on return/enter in Mozilla/Firefox. The default value of this option is true. ',
         'type' => 'combo-boolean',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -122,6 +122,15 @@ $settings['tiny.entity_encoding']->fromArray(array(
     'area' => 'cleanup-output',
 ),'',true,true);
 
+$settings['tiny.entities']= $modx->newObject('modSystemSetting');
+$settings['tiny.entities']->fromArray(array(
+    'key' => 'tiny.entities',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'tinymce',
+    'area' => 'cleanup-output',
+),'',true,true);
+
 $settings['tiny.fix_nesting']= $modx->newObject('modSystemSetting');
 $settings['tiny.fix_nesting']->fromArray(array(
     'key' => 'tiny.fix_nesting',

--- a/core/components/tinymce/tinymce.class.php
+++ b/core/components/tinymce/tinymce.class.php
@@ -93,7 +93,7 @@ class TinyMCE {
             'css_path' => $this->context->getOption('editor_css_path','',$this->properties),
             'directionality' => $this->context->getOption('manager_direction','ltr',$this->properties),
             'element_format' => $this->context->getOption('tiny.element_format','xhtml',$this->properties),
-            'entity_encoding' => $this->context->getOption('tiny.element_format','named',$this->properties),
+            'entity_encoding' => $this->context->getOption('tiny.entity_encoding','named',$this->properties),
             'fix_nesting' => $this->context->getOption('tiny.fix_nesting',false,$this->properties),
             'fix_table_elements' => $this->context->getOption('tiny.fix_table_elements',false,$this->properties),
             'font_size_classes' => $this->context->getOption('tiny.font_size_classes','',$this->properties),

--- a/core/components/tinymce/tinymce.class.php
+++ b/core/components/tinymce/tinymce.class.php
@@ -94,6 +94,7 @@ class TinyMCE {
             'directionality' => $this->context->getOption('manager_direction','ltr',$this->properties),
             'element_format' => $this->context->getOption('tiny.element_format','xhtml',$this->properties),
             'entity_encoding' => $this->context->getOption('tiny.entity_encoding','named',$this->properties),
+            'entities' => $this->context->getOption('tiny.entities','',$this->properties),
             'fix_nesting' => $this->context->getOption('tiny.fix_nesting',false,$this->properties),
             'fix_table_elements' => $this->context->getOption('tiny.fix_table_elements',false,$this->properties),
             'font_size_classes' => $this->context->getOption('tiny.font_size_classes','',$this->properties),


### PR DESCRIPTION
The 'entity_encoding' parameter loaded wrong 'tiny.element_format' value, this bug probably originated by wrong duplication of code.

Also, added "entities" parameter so MODX user can pass the values to TinyMCE:
https://www.tinymce.com/docs-3x/reference/configuration/Configuration3x@entities/