### PR TITLE
Change onCleanup regex

### DIFF
--- a/assets/components/tinymce/tiny.js
+++ b/assets/components/tinymce/tiny.js
@@ -92,8 +92,8 @@ var Tiny = {
 	    switch (type) {
             case "get_from_editor":
             case "insert_to_editor":
-                var regexp = /(\[\[[^\]]*)&amp;([^\[]*\]\])/g;
-                value = value.replace(regexp,'$1&$2');
+                var regexp = /&amp;([^=`]*=`[^`]*`)/g;
+                value = value.replace(regexp,'&$1');
             break;
             case "submit_content":
                 //value.innerHTML = value.innerHTML.replace('&amp;','&');


### PR DESCRIPTION
The current regex only fixes the last ampersand within modx tags with multiple properties being set. This takes a different approach, not attempting to focus in on content within opening/closing double brackets but rather on the parameter format itself (which is highly unlikely to be used in normal text). This would also allow for ampersands within nested tags to be easily converted too, sidestepping the need for an overly-complex regex.