### PR TITLE
Problem with strict MIME type checking of Chrome

### DIFF
--- a/assets/components/tinymce/template.list.php
+++ b/assets/components/tinymce/template.list.php
@@ -2,6 +2,7 @@
 /**
  * @package tinymce
  */
+header("Content-type: application/javascript");
 require dirname(__FILE__).'/connector.php';
 
 $templates = $modx->tinymce->getTemplateList();


### PR DESCRIPTION
This file produces Java Script that is loaded via Document Write 

`<script language="javascript" type="text/javascript" src="http://www.waldruhe.usw/assets/components/tinymce/template.list.php"></script>`

The php file returns _text/html_. Chrome ignores this script because of strict MIME type
checking. It expects _application/javascript_.
