### PR TITLE
Add prepending search results by context key

### DIFF
--- a/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/search.php
+++ b/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/search.php
@@ -1,29 +1,42 @@
 <?php
 /**
  * Handles dynamic search
- *
  * @package tinymce
  */
-require_once dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__)))))))).'/config.core.php';
-require_once MODX_CORE_PATH.'config/'.MODX_CONFIG_KEY.'.inc.php';
-require_once MODX_CONNECTORS_PATH.'index.php';
+require_once dirname(dirname(dirname(dirname(dirname(dirname(dirname(dirname(__FILE__)))))))) . '/config.core.php';
+require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
+require_once MODX_CONNECTORS_PATH . 'index.php';
 
-$searchMode = $modx->getOption('search-mode',$_REQUEST,'pagetitle');
-$query = $modx->getOption('q',$_REQUEST,'');
+$searchMode = $modx->getOption('search-mode', $_REQUEST, 'pagetitle');
+$query = $modx->getOption('q', $_REQUEST, '');
 
 $c = $modx->newQuery('modResource');
 $c->where(array(
-    $searchMode.':LIKE' => '%'.$query.'%',
+    $searchMode . ':LIKE' => '%' . $query . '%',
 ));
 
-$count = $modx->getCount('modResource',$c);
+$count = $modx->getCount('modResource', $c);
 
-$c->select(array('id','pagetitle','alias'));
+$c->select(array('id', 'pagetitle', 'alias', 'context_key'));
 $c->limit(10);
 
-$resources = $modx->getCollection('modResource',$c);
+$resources = $modx->getCollection('modResource', $c);
 
+$output = array();
+/** @var modResource $resource */
 foreach ($resources as $resource) {
-    echo $resource->get('pagetitle').' ('.$resource->get('id').')|'.$resource->get('id')."\n";
+    $output[] = array(
+        'id' => $resource->get('id'),
+        'context' => $resource->get('context_key'),
+        'title' => $resource->get('pagetitle'),
+    );
 }
+
+$contexts = array_unique(array_column($output, 'context'));
+
+echo implode(PHP_EOL, array_map(function ($row) use($contexts) {
+    return count($contexts) > 1
+        ? sprintf('%s - %s (%d)|%d', $row['context'], $row['title'], $row['id'], $row['id'])
+        : sprintf('%s (%d)|%d', $row['title'], $row['id'], $row['id']);
+}, $output));
 die();


### PR DESCRIPTION
Needed when search results have a lot of similar pages from different contexts

![context-prepend](https://user-images.githubusercontent.com/303498/53744528-46871400-3eae-11e9-8b4b-aa4f0eddccfd.png)

When in results only one context, works as before.